### PR TITLE
Fix broken querySelector due to github markup changes

### DIFF
--- a/packages/content/pages/GitHub.ts
+++ b/packages/content/pages/GitHub.ts
@@ -11,7 +11,7 @@ import { isRepoRoot, isHistoryForFile, isRepoTree, isSingleFile, isCommit, isGis
 import { mutate } from 'fastdom';
 import { getFileIcon, getFolderIcon } from '../utils/Dev';
 
-const QUERY_NAVIGATION_ITEMS = '.file-wrap>table>tbody:last-child>tr.js-navigation-item';
+const QUERY_NAVIGATION_ITEMS = 'table.js-navigation-container>tbody:last-child>tr.js-navigation-item';
 const QUERY_PATH_SEGMENTS = 'js-path-segment';
 const QUERY_LAST_PATH_SEGMENT = 'final-path';
 


### PR DESCRIPTION
Fist of all, thanks for the awesome extension, I love it!!!!
Sadly, as of today it is broken, since github changed its makup.
Luckily I still had a tab from yesterday open and could find the changes.

__Old makup__
```html
<div class="file-wrap">
...
  <table class="files js-navigation-container js-active-navigation-container" data-pjax="">
```

__New makup__
```html
<div class="Box Box--condensed mb-3">
...
  <table class="files js-navigation-container js-active-navigation-container" data-pjax="">
```
Due to this change, the querySelectorAll:
https://github.com/dderevjanik/github-vscode-icons/blob/0885747fffea9fa543243daf097e3ffb5e8af2e8/packages/content/pages/GitHub.ts#L57

isn't able to find `tr.js-navigation-item`'s. 
My proposed change is able to find `tr.js-navigation-item`'s in the old, as well as the new markup.