### PR TITLE
vertically adjust github icons

### DIFF
--- a/build/content.css
+++ b/build/content.css
@@ -43,7 +43,7 @@ td.icon > img  {
 }
 
 .vscode-icon {
-    vertical-align: middle;
+    vertical-align: -3px;
     height: 16px;
 }
 

--- a/packages/content/pages/GitHub.ts
+++ b/packages/content/pages/GitHub.ts
@@ -95,7 +95,7 @@ function showRepoTreeIcons(rowEl: Element) {
         return;
       }
       const x = mutate(() => {
-        iconSVGEl.outerHTML = `<img src="${getIconUrl(iconPath)}" class="${iconSVGClassName}" alt="icon" width="16" height="16">`;
+        iconSVGEl.outerHTML = `<img src="${getIconUrl(iconPath)}" class="vscode-icon ${iconSVGClassName}" alt="icon" width="16" height="16">`;
       });
     }
     // else {


### PR DESCRIPTION
Fixes #28 

Tested OK on GitHub with Chrome 85.